### PR TITLE
cumulate errors in bulk indexer

### DIFF
--- a/core/bulk.go
+++ b/core/bulk.go
@@ -120,12 +120,8 @@ type BulkIndexer struct {
 
 	// shutdown channel
 	shutdownChan chan bool
-	// Channel to shutdown http send go-routines
-	httpDoneChan chan bool
 	// channel to shutdown timer
 	timerDoneChan chan bool
-	// channel to shutdown doc go-routines
-	docDoneChan chan bool
 
 	// Channel to send a complete byte.Buffer to the http sendor
 	sendBuf chan *bytes.Buffer
@@ -150,8 +146,10 @@ type BulkIndexer struct {
 	// Wait Group for the http sends
 	sendWg *sync.WaitGroup
 
-	// wait group to wait on shutdown for all goros
-	gorosWg *sync.WaitGroup
+	// wait group for http calls goros
+	httpWg *sync.WaitGroup
+	// wait group for doc goro
+	docWg *sync.WaitGroup
 }
 
 func NewBulkIndexer(maxConns int) *BulkIndexer {
@@ -164,10 +162,9 @@ func NewBulkIndexer(maxConns int) *BulkIndexer {
 	b.BufferDelayMax = time.Duration(BulkDelaySeconds) * time.Second
 	b.bulkChannel = make(chan []byte, 100)
 	b.sendWg = new(sync.WaitGroup)
-	b.docDoneChan = make(chan bool)
 	b.timerDoneChan = make(chan bool)
-	b.httpDoneChan = make(chan bool)
-	b.gorosWg = new(sync.WaitGroup)
+	b.httpWg = new(sync.WaitGroup)
+	b.docWg = new(sync.WaitGroup)
 	b.errs = &syncErrorList{}
 	return &b
 }
@@ -198,6 +195,7 @@ func (b *BulkIndexer) Run(done chan bool) <-chan error {
 		b.startHttpSender()
 		b.startDocChannel()
 		b.startTimer()
+
 		<-b.shutdownChan
 		b.Flush()
 		b.shutdown()
@@ -232,57 +230,47 @@ func (b *BulkIndexer) Flush() {
 		b.send(b.buf)
 	}
 	b.mu.Unlock()
-	for {
-		select {
-		case <-wgChan(b.sendWg):
-			// done
-			return
-		case <-time.After(time.Second * time.Duration(MAX_SHUTDOWN_SECS)):
-			// timeout!
-			return
-		}
+	select {
+	case <-wgChan(b.sendWg):
+		// done
+		return
+	case <-time.After(time.Second * time.Duration(MAX_SHUTDOWN_SECS)):
+		// timeout!
+		return
 	}
 }
 
 func (b *BulkIndexer) startHttpSender() {
-
 	// this sends http requests to elasticsearch it uses maxConns to open up that
 	// many goroutines, each of which will synchronously call ElasticSearch
 	// in theory, the whole set will cause a backup all the way to IndexBulk if
 	// we have consumed all maxConns
-	b.gorosWg.Add(b.maxConns)
+	b.httpWg.Add(b.maxConns)
 	for i := 0; i < b.maxConns; i++ {
 		go func() {
-			defer b.gorosWg.Done()
+			defer b.httpWg.Done()
 
-			for {
-				select {
-				case buf := <-b.sendBuf:
-					b.sendWg.Add(1)
-					err := b.BulkSender(buf)
+			for buf := range b.sendBuf {
+				b.sendWg.Add(1)
+				err := b.BulkSender(buf)
 
-					// Perhaps a b.FailureStrategy(err)  ??  with different types of strategies
-					//  1.  Retry, then panic
-					//  2.  Retry then return error and let runner decide
-					//  3.  Retry, then log to disk?   retry later?
-					if err != nil {
-						if b.RetryForSeconds > 0 {
-							time.Sleep(time.Second * time.Duration(b.RetryForSeconds))
-							err = b.BulkSender(buf)
-							if err == nil {
-								// Successfully re-sent with no error
-								b.sendWg.Done()
-								continue
-							}
+				// Perhaps a b.FailureStrategy(err)  ??  with different types of strategies
+				//  1.  Retry, then panic
+				//  2.  Retry then return error and let runner decide
+				//  3.  Retry, then log to disk?   retry later?
+				if err != nil {
+					if b.RetryForSeconds > 0 {
+						time.Sleep(time.Second * time.Duration(b.RetryForSeconds))
+						err = b.BulkSender(buf)
+						if err == nil {
+							// Successfully re-sent with no error
+							b.sendWg.Done()
+							continue
 						}
-						b.errs.add(err)
 					}
-					b.sendWg.Done()
-				case <-b.httpDoneChan:
-					// shutdown this go routine
-					return
+					b.errs.add(err)
 				}
-
+				b.sendWg.Done()
 			}
 		}()
 	}
@@ -292,10 +280,7 @@ func (b *BulkIndexer) startHttpSender() {
 // even if we haven't hit max messages/size
 func (b *BulkIndexer) startTimer() {
 	ticker := time.NewTicker(b.BufferDelayMax)
-	b.gorosWg.Add(1)
 	go func() {
-		defer b.gorosWg.Done()
-
 		for {
 			select {
 			case <-ticker.C:
@@ -314,7 +299,6 @@ func (b *BulkIndexer) startTimer() {
 				// shutdown this go routine
 				return
 			}
-
 		}
 	}()
 }
@@ -322,27 +306,28 @@ func (b *BulkIndexer) startTimer() {
 func (b *BulkIndexer) startDocChannel() {
 	// This goroutine accepts incoming byte arrays from the IndexBulk function and
 	// writes to buffer
-	b.gorosWg.Add(1)
+	b.docWg.Add(1)
 	go func() {
-		defer b.gorosWg.Done()
+		defer b.docWg.Done()
 
-		for {
-			select {
-			case docBytes := <-b.bulkChannel:
-				b.mu.Lock()
-				b.docCt += 1
-				b.buf.Write(docBytes)
-				if b.buf.Len() >= b.BulkMaxBuffer || b.docCt >= b.BulkMaxDocs {
-					b.needsTimeBasedFlush = false
-					//log.Printf("Send due to size:  docs=%d  bufsize=%d", b.docCt, b.buf.Len())
-					b.send(b.buf)
-				}
-				b.mu.Unlock()
-			case <-b.docDoneChan:
-				// shutdown this go routine
-				return
+		for docBytes := range b.bulkChannel {
+			b.mu.Lock()
+			b.docCt += 1
+			b.buf.Write(docBytes)
+			if b.buf.Len() >= b.BulkMaxBuffer || b.docCt >= b.BulkMaxDocs {
+				b.needsTimeBasedFlush = false
+				//log.Printf("Send due to size:  docs=%d  bufsize=%d", b.docCt, b.buf.Len())
+				b.send(b.buf)
 			}
+			b.mu.Unlock()
 		}
+
+		// enqueue the remaning bytes, if any
+		b.mu.Lock()
+		if b.docCt > 0 {
+			b.send(b.buf)
+		}
+		b.mu.Unlock()
 	}()
 }
 
@@ -356,12 +341,11 @@ func (b *BulkIndexer) send(buf *bytes.Buffer) {
 
 func (b *BulkIndexer) shutdown() {
 	// This must be called After flush
-	b.docDoneChan <- true
+	close(b.bulkChannel)
+	b.docWg.Wait()
+	close(b.sendBuf)
+	b.httpWg.Wait()
 	b.timerDoneChan <- true
-	for i := 0; i < b.maxConns; i++ {
-		b.httpDoneChan <- true
-	}
-	b.gorosWg.Wait()
 }
 
 // The index bulk API adds or updates a typed JSON document to a specific index, making it searchable.

--- a/core/bulk_test.go
+++ b/core/bulk_test.go
@@ -187,8 +187,8 @@ func TestBulkErrors(t *testing.T) {
 	}
 	done <- true
 	err := <-errCh
-	t.Logf("Error is: %#v", err)
 	assert.NotEqual(t, nil, err, fmt.Sprintf("error should not be nil"))
+	assert.Equal(t, "FAIL", err.Error(), "error should be the expected one")
 }
 
 /*

--- a/core/bulk_test.go
+++ b/core/bulk_test.go
@@ -15,6 +15,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -171,34 +172,23 @@ func TestBulkSmallBatch(t *testing.T) {
 
 }
 
-func XXXTestBulkErrors(t *testing.T) {
-	// lets set a bad port, and hope we get a connection refused error?
-	api.Port = "27845"
-	defer func() {
-		api.Port = "9200"
-	}()
+func TestBulkErrors(t *testing.T) {
 	BulkDelaySeconds = 1
-	indexer := NewBulkIndexerErrors(10, 1)
+	indexer := NewBulkIndexerRetry(10, 1)
+	indexer.BulkSender = func(_ *bytes.Buffer) error {
+		return errors.New("FAIL")
+	}
 	done := make(chan bool)
-	indexer.Run(done)
-	errorCt := 0
-	go func() {
-		for i := 0; i < 20; i++ {
-			date := time.Unix(1257894000, 0)
-			data := map[string]interface{}{"name": "smurfs", "age": 22, "date": time.Unix(1257894000, 0)}
-			indexer.Index("users", "user", strconv.Itoa(i), "", &date, data, true)
-		}
-	}()
-	var errBuf *ErrorBuffer
-	for errBuf = range indexer.ErrorChannel {
-		errorCt++
-		break
+	errCh := indexer.Run(done)
+	for i := 0; i < 20; i++ {
+		date := time.Unix(1257894000, 0)
+		data := map[string]interface{}{"name": "smurfs", "age": 22, "date": time.Unix(1257894000, 0)}
+		indexer.Index("users", "user", strconv.Itoa(i), "", &date, data, true)
 	}
-	if errBuf.Buf.Len() > 0 {
-		gou.Debug(errBuf.Err)
-	}
-	assert.T(t, errorCt > 0, fmt.Sprintf("ErrorCt should be > 0 %d", errorCt))
 	done <- true
+	err := <-errCh
+	t.Logf("Error is: %#v", err)
+	assert.NotEqual(t, nil, err, fmt.Sprintf("error should not be nil"))
 }
 
 /*


### PR DESCRIPTION
The bulk indexer is still racy, as seen by the `TestBulkErrors` random failures. This is not caused by this change, this was already the case (the TestBulkErrors test was actually commented out in the original version).

I will try to fix the biggest issue - the data race that causes some index requests to not be executed before the indexer stops - but the code is brittle and overly complex, I would still recommend using a different package or a major rewrite of this.