### PR TITLE
Add recursion when extracting aggregates

### DIFF
--- a/lib/coreaggregate.go
+++ b/lib/coreaggregate.go
@@ -1,8 +1,6 @@
 package elastigo
 
-import (
-	"encoding/json"
-)
+import "encoding/json"
 
 // AggregateBucket holds information about a bucket-type aggregate
 // as returned by an ES query.
@@ -34,6 +32,7 @@ func ExtractAggregates(sr *SearchResult) ([]*AggregateBucket, error) {
 			Name:     k,
 			KeyCount: make(map[string]int),
 		}
+
 		if vm, ok := v.(map[string]interface{}); ok {
 			if buck, ok := vm["buckets"]; ok {
 				// buck should be an array of maps having two keys each, "key"

--- a/lib/coreaggregate.go
+++ b/lib/coreaggregate.go
@@ -28,31 +28,49 @@ func ExtractAggregates(sr *SearchResult) ([]*AggregateBucket, error) {
 	}
 	var aggs []*AggregateBucket
 	for k, v := range m {
-		agg := AggregateBucket{
-			Name:     k,
-			KeyCount: make(map[string]int),
+		bucket := extractAggBucket(k, v)
+		if len(bucket.KeyCount) > 0 {
+			aggs = append(aggs, bucket)
 		}
+	}
+	return aggs, nil
+}
 
-		if vm, ok := v.(map[string]interface{}); ok {
-			if buck, ok := vm["buckets"]; ok {
-				// buck should be an array of maps having two keys each, "key"
-				// and "doc_count"
-				if ar, ok := buck.([]interface{}); ok {
-					for _, kdc := range ar {
-						if mkdc, ok := kdc.(map[string]interface{}); ok {
-							if k, ok := mkdc["key"]; ok {
-								if cnt, ok := mkdc["doc_count"]; ok {
-									agg.KeyCount[k.(string)] = int(cnt.(float64))
-								}
-							}
-						}
+func extractAggBucket(k string, v interface{}) *AggregateBucket {
+	agg := &AggregateBucket{
+		Name:     k,
+		KeyCount: make(map[string]int),
+	}
+
+	vm, ok := v.(map[string]interface{})
+	if !ok {
+		return agg
+	}
+
+	buck, ok := vm["buckets"]
+	if !ok {
+		// OK, we have to go down a level. Hang on.
+		for k, v := range vm {
+			if k == "doc_count" {
+				continue
+			}
+			// ... and recurse.
+			return extractAggBucket(k, v)
+		}
+		return agg
+	}
+	// buck should be an array of maps having two keys each, "key"
+	// and "doc_count"
+	if ar, ok := buck.([]interface{}); ok {
+		for _, kdc := range ar {
+			if mkdc, ok := kdc.(map[string]interface{}); ok {
+				if k, ok := mkdc["key"]; ok {
+					if cnt, ok := mkdc["doc_count"]; ok {
+						agg.KeyCount[k.(string)] = int(cnt.(float64))
 					}
 				}
 			}
 		}
-		if len(agg.KeyCount) > 0 {
-			aggs = append(aggs, &agg)
-		}
 	}
-	return aggs, nil
+	return agg
 }

--- a/lib/coreaggregate_test.go
+++ b/lib/coreaggregate_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestExtractAggregates(t *testing.T) {
-	s := `
+	agg1 := `
 	{
 		"instruments": {
 			"doc_count_error_upper_bound": 0,
@@ -52,35 +52,75 @@ func TestExtractAggregates(t *testing.T) {
 	}
 	`
 
-	sr := &SearchResult{Aggregations: []byte(s)}
-
-	buckets, err := ExtractAggregates(sr)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(buckets) != 2 {
-		t.Fatalf("got %d aggregates, expected 2", len(buckets))
-	}
-
-	for _, bucket := range buckets {
-		switch bucket.Name {
-		case "tags":
-			if len(bucket.KeyCount) == 3 {
-				assert.Equal(t, 2, bucket.KeyCount["drum"])
-				assert.Equal(t, 3, bucket.KeyCount["house"])
-				assert.Equal(t, 1, bucket.KeyCount["bass"])
-			} else {
-				t.Errorf("got %d keys in 'tags' bucket, expected 3", len(bucket.KeyCount))
+	agg2 := `{
+		"people": {
+			"doc_count": 5,
+			"friends": {
+				"doc_count_error_upper_bound": 0,
+				"sum_other_doc_count": 0,
+				"buckets": [
+					{
+						"key": "alice",
+						"doc_count": 2
+					},
+					{
+						"key": "bob",
+						"doc_count": 1
+					}
+				]
 			}
-		case "instruments":
-			if len(bucket.KeyCount) == 4 {
-				assert.Equal(t, 4, bucket.KeyCount["drums"])
-				assert.Equal(t, 1, bucket.KeyCount["cello"])
-				assert.Equal(t, 3, bucket.KeyCount["violin"])
-				assert.Equal(t, 2, bucket.KeyCount["bongo"])
-			} else {
-				t.Errorf("got %d keys in 'instruments' bucket, expected 4", len(bucket.KeyCount))
+		}
+	}`
+
+	testCases := []struct {
+		agg         string
+		bucketCount int
+	}{
+		{agg1, 2},
+		{agg2, 1},
+	}
+	for i, tc := range testCases {
+
+		sr := &SearchResult{Aggregations: []byte(tc.agg)}
+
+		buckets, err := ExtractAggregates(sr)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(buckets) != tc.bucketCount {
+			t.Errorf("Expected case %d to have a bucket count of %d, but got %d", i, tc.bucketCount, len(buckets))
+			continue
+		}
+
+		for _, bucket := range buckets {
+			switch bucket.Name {
+			case "tags":
+				if len(bucket.KeyCount) == 3 {
+					assert.Equal(t, 2, bucket.KeyCount["drum"])
+					assert.Equal(t, 3, bucket.KeyCount["house"])
+					assert.Equal(t, 1, bucket.KeyCount["bass"])
+				} else {
+					t.Errorf("got %d keys in 'tags' bucket, expected 3", len(bucket.KeyCount))
+				}
+			case "instruments":
+				if len(bucket.KeyCount) == 4 {
+					assert.Equal(t, 4, bucket.KeyCount["drums"])
+					assert.Equal(t, 1, bucket.KeyCount["cello"])
+					assert.Equal(t, 3, bucket.KeyCount["violin"])
+					assert.Equal(t, 2, bucket.KeyCount["bongo"])
+				} else {
+					t.Errorf("got %d keys in 'instruments' bucket, expected 4", len(bucket.KeyCount))
+				}
+			case "friends":
+				if len(bucket.KeyCount) == 2 {
+					assert.Equal(t, 2, bucket.KeyCount["alice"])
+					assert.Equal(t, 1, bucket.KeyCount["bob"])
+				} else {
+					t.Errorf("got %d keys in 'friends' bucket, expected 2", len(bucket.KeyCount))
+				}
+			default:
+				t.Errorf("case %d: Unexpected key %s", i, bucket.Name)
 			}
 		}
 	}

--- a/lib/coreaggregate_test.go
+++ b/lib/coreaggregate_test.go
@@ -1,0 +1,87 @@
+package elastigo
+
+import (
+	"testing"
+
+	"github.com/bmizerany/assert"
+)
+
+func TestExtractAggregates(t *testing.T) {
+	s := `
+	{
+		"instruments": {
+			"doc_count_error_upper_bound": 0,
+			"sum_other_doc_count": 0,
+			"buckets": [
+				{
+					"key": "violin",
+					"doc_count": 3
+				},
+				{
+					"key": "bongo",
+					"doc_count": 2
+				},
+				{
+					"key": "cello",
+					"doc_count": 1
+				},
+				{
+					"key": "drums",
+					"doc_count": 4
+				}
+			]
+		},
+		"tags": {
+			"doc_count_error_upper_bound": 0,
+			"sum_other_doc_count": 0,
+			"buckets": [
+				{
+					"key": "drum",
+					"doc_count": 2
+				},
+				{
+					"key": "house",
+					"doc_count": 3
+				},
+				{
+					"key": "bass",
+					"doc_count": 1
+				}
+			]
+		}
+	}
+	`
+
+	sr := &SearchResult{Aggregations: []byte(s)}
+
+	buckets, err := ExtractAggregates(sr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(buckets) != 2 {
+		t.Fatalf("got %d aggregates, expected 2", len(buckets))
+	}
+
+	for _, bucket := range buckets {
+		switch bucket.Name {
+		case "tags":
+			if len(bucket.KeyCount) == 3 {
+				assert.Equal(t, 2, bucket.KeyCount["drum"])
+				assert.Equal(t, 3, bucket.KeyCount["house"])
+				assert.Equal(t, 1, bucket.KeyCount["bass"])
+			} else {
+				t.Errorf("got %d keys in 'tags' bucket, expected 3", len(bucket.KeyCount))
+			}
+		case "instruments":
+			if len(bucket.KeyCount) == 4 {
+				assert.Equal(t, 4, bucket.KeyCount["drums"])
+				assert.Equal(t, 1, bucket.KeyCount["cello"])
+				assert.Equal(t, 3, bucket.KeyCount["violin"])
+				assert.Equal(t, 2, bucket.KeyCount["bongo"])
+			} else {
+				t.Errorf("got %d keys in 'instruments' bucket, expected 4", len(bucket.KeyCount))
+			}
+		}
+	}
+}


### PR DESCRIPTION
It turns out the data that I got back was nested slightly differently than the data that Martin's query gets back.

We may find that this blows up or goes into an infinite loop if we have more than 2 conditions in the aggregate, but we'll find out when that happens, and it should be easy to test.