### PR TITLE
Remove the refresh flag from bulk indexing

### DIFF
--- a/lib/corebulk_test.go
+++ b/lib/corebulk_test.go
@@ -81,7 +81,7 @@ func TestBulkIndexerBasic(t *testing.T) {
 		"date": "yesterday",
 	}
 
-	if err := indexer.Index(testIndex, "user", "1", "", "", &date, data, true); err != nil {
+	if err := indexer.Index(testIndex, "user", "1", "", "", &date, data); err != nil {
 		t.Fatal(err)
 	}
 
@@ -94,10 +94,10 @@ func TestBulkIndexerBasic(t *testing.T) {
 	//totalBytesSent = totalBytesSent - len(*eshost)
 	assert.T(t, len(buffers) == 1, fmt.Sprintf("Should have sent one operation but was %d", len(buffers)))
 	assert.T(t, indexer.NumErrors() == 0, fmt.Sprintf("Should not have any errors. NumErrors: %v", indexer.NumErrors()))
-	expectedBytes := 144
+	expectedBytes := 129
 	assert.T(t, totalBytesSent == expectedBytes, fmt.Sprintf("Should have sent %v bytes but was %v", expectedBytes, totalBytesSent))
 
-	if err := indexer.Index(testIndex, "user", "2", "", "", nil, data, true); err != nil {
+	if err := indexer.Index(testIndex, "user", "2", "", "", nil, data); err != nil {
 		t.Fatal(err)
 	}
 	<-time.After(time.Millisecond * 10) // we need to wait for doc to hit send channel
@@ -108,7 +108,7 @@ func TestBulkIndexerBasic(t *testing.T) {
 	assert.T(t, len(buffers) == 2, fmt.Sprintf("Should have another buffer ct=%d", len(buffers)))
 
 	assert.T(t, indexer.NumErrors() == 0, fmt.Sprintf("Should not have any errors %d", indexer.NumErrors()))
-	expectedBytes = 250 // with refresh
+	expectedBytes = 220 // with refresh
 	assert.T(t, closeInt(totalBytesSent, expectedBytes), fmt.Sprintf("Should have sent %v bytes but was %v", expectedBytes, totalBytesSent))
 }
 
@@ -146,7 +146,7 @@ func XXXTestBulkUpdate(t *testing.T) {
 	data := map[string]interface{}{
 		"script": "ctx._source.count += 2",
 	}
-	if err := indexer.Update("users", "user", "5", "", "", &date, data, true); err != nil {
+	if err := indexer.Update("users", "user", "5", "", "", &date, data); err != nil {
 		t.Fatal(err)
 	}
 	// So here's the deal. Flushing does seem to work, you just have to give the
@@ -196,9 +196,9 @@ func TestBulkSmallBatch(t *testing.T) {
 	indexer.Start()
 	<-time.After(time.Millisecond * 20)
 
-	indexer.Index("users", "user", "2", "", "", &date, data, true)
-	indexer.Index("users", "user", "3", "", "", &date, data, true)
-	indexer.Index("users", "user", "4", "", "", &date, data, true)
+	indexer.Index("users", "user", "2", "", "", &date, data)
+	indexer.Index("users", "user", "3", "", "", &date, data)
+	indexer.Index("users", "user", "4", "", "", &date, data)
 	<-time.After(time.Millisecond * 200)
 	//	indexer.Flush()
 	if err := indexer.Stop(); err != nil {
@@ -222,7 +222,7 @@ func TestBulkDelete(t *testing.T) {
 
 	indexer.Start()
 
-	indexer.Delete("fake", "fake_type", "1", true)
+	indexer.Delete("fake", "fake_type", "1")
 
 	indexer.Flush()
 	if err := indexer.Stop(); err != nil {
@@ -231,7 +231,7 @@ func TestBulkDelete(t *testing.T) {
 
 	sent := string(sentBytes)
 
-	expected := `{"delete":{"_index":"fake","_type":"fake_type","_id":"1","refresh":true}}
+	expected := `{"delete":{"_index":"fake","_type":"fake_type","_id":"1"}}
 `
 	asExpected := sent == expected
 	assert.T(t, asExpected, fmt.Sprintf("Should have sent '%s' but actually sent '%s'", expected, sent))
@@ -247,7 +247,7 @@ func TestBulkErrors(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		date := time.Unix(1257894000, 0)
 		data := map[string]interface{}{"name": "smurfs", "age": 22, "date": date}
-		indexer.Index("users", "user", strconv.Itoa(i), "", "", &date, data, true)
+		indexer.Index("users", "user", strconv.Itoa(i), "", "", &date, data)
 	}
 	err := indexer.Stop()
 	assert.NotEqual(t, nil, err, fmt.Sprintf("error should not be nil"))
@@ -279,7 +279,7 @@ func BenchmarkSend(b *testing.B) {
 		about := make([]byte, 1000)
 		rand.Read(about)
 		data := map[string]interface{}{"name": "smurfs", "age": 22, "date": time.Unix(1257894000, 0), "about": about}
-		indexer.Index("users", "user", strconv.Itoa(i), "", "", nil, data, true)
+		indexer.Index("users", "user", strconv.Itoa(i), "", "", nil, data)
 	}
 	log.Printf("Sent %d messages in %d sets totaling %d bytes \n", b.N, sets, totalBytes)
 	if indexer.NumErrors() != 0 {
@@ -313,7 +313,7 @@ func BenchmarkSendBytes(b *testing.B) {
 		return indexer.Send(buf)
 	}
 	for i := 0; i < b.N; i++ {
-		indexer.Index("users", "user", strconv.Itoa(i), "", "", nil, body, true)
+		indexer.Index("users", "user", strconv.Itoa(i), "", "", nil, body)
 	}
 	log.Printf("Sent %d messages in %d sets totaling %d bytes \n", b.N, sets, totalBytes)
 	if indexer.NumErrors() != 0 {

--- a/lib/coreexample_test.go
+++ b/lib/coreexample_test.go
@@ -25,7 +25,7 @@ func ExampleBulkIndexer_simple() {
 
 	indexer := c.NewBulkIndexerRetry(10, 60)
 	indexer.Start()
-	indexer.Index("twitter", "user", "1", "", "", nil, `{"name":"bob"}`, true)
+	indexer.Index("twitter", "user", "1", "", "", nil, `{"name":"bob"}`)
 	if err := indexer.Stop(); err != nil {
 		// handle error
 	}
@@ -48,7 +48,7 @@ func ExampleBulkIndexer_responses() {
 	}
 	indexer.Start()
 	for i := 0; i < 20; i++ {
-		indexer.Index("twitter", "user", strconv.Itoa(i), "", "", nil, `{"name":"bob"}`, true)
+		indexer.Index("twitter", "user", strconv.Itoa(i), "", "", nil, `{"name":"bob"}`)
 	}
 	if err := indexer.Stop(); err != nil {
 		// handle error

--- a/lib/coretest_test.go
+++ b/lib/coretest_test.go
@@ -179,7 +179,7 @@ func LoadTestData() {
 				log.Println("HM, already exists? ", ge.Url)
 			}
 			docsm[id] = true
-			indexer.Index(testIndex, ge.Type, id, "", "", &ge.Created, line, true)
+			indexer.Index(testIndex, ge.Type, id, "", "", &ge.Created, line)
 			docCt++
 		} else {
 			log.Println("ERROR? ", string(line))


### PR DESCRIPTION
We have a conflict between the production and staging versions
of elasticsearch. Staging is running v1.6.0 and production is running
v1.4.4.

There is an undocumented breaking change between the 1.4 version and
1.6: the bulk indexer does not accept a "refresh" flag in the metadata
per document. It does, however accept a ?refresh argument as a query
param, so if we ever need this, we can add that behavior to the bulk
sender Send() method, which calls DoCommand().

We have never used this feature (it is expensive, we don't need it,
we've always passed refresh=false).