### PR TITLE
Fix name of retry parameter in bulk update request

### DIFF
--- a/lib/corebulk.go
+++ b/lib/corebulk.go
@@ -459,7 +459,7 @@ func WriteBulkBytes(op, index, _type, id, parent, ttl string, date *time.Time, d
 	}
 
 	if op == "update" {
-		buf.WriteString(`,"retry_on_conflict":3`)
+		buf.WriteString(`,"_retry_on_conflict":3`)
 	}
 
 	if len(ttl) > 0 {


### PR DESCRIPTION
This was an undocumented breaking change between 1.4.x and 1.6.0.